### PR TITLE
Support React 15

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lodash.isarray": "^4.0.0",
     "lodash.isobject": "^3.0.2",
     "merge": "^1.2.0",
-    "react": "^0.14.0"
+    "react": "^15.0.0"
   },
   "devDependencies": {
     "babel-core": "^6.6.4",
@@ -49,7 +49,7 @@
     "mocha": "^2.2.1",
     "mocha-sinon": "^1.1.5",
     "normalize.css": "^3.0.3",
-    "react-addons-test-utils": "^0.14.0",
+    "react-addons-test-utils": "^15.0.0",
     "react-hot-loader": "^1.2.5",
     "react-map-styles": "git://github.com/casesandberg/react-map-styles",
     "remarkable": "^1.6.0",


### PR DESCRIPTION
Simply update dependencies to allow React 15+.  Tests pass.  Will be looking for other ways to verify behavior.
